### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/torngithub.py
+++ b/torngithub.py
@@ -97,14 +97,14 @@ class GithubMixin(OAuth2Mixin):
                          future, fields, response):
         if response.error:
             future.set_exception(
-                AuthError("Github auth error: %s" % str(response)))
+                AuthError("Github auth error: {0!s}".format(str(response))))
             return
 
         args = parse_qs_bytes(native_str(response.body))
 
         if "error" in args:
             future.set_exception(
-                AuthError("Github auth error: %s" % args["error"][-1]))
+                AuthError("Github auth error: {0!s}".format(args["error"][-1])))
             return
 
         session = {
@@ -185,8 +185,7 @@ def _on_github_request(future, response):
     if response.error:
         print response.error
         future.set_exception(
-            AuthError("Error response %s fetching %s" %
-                      (response.error, response.request.url)))
+            AuthError("Error response {0!s} fetching {1!s}".format(response.error, response.request.url)))
         return
 
     result = ObjectDict(code=response.code, headers=response.headers, body=None)


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:torngithub?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:torngithub?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
